### PR TITLE
Added correct German translation

### DIFF
--- a/messages/de/kvdrp.php
+++ b/messages/de/kvdrp.php
@@ -19,7 +19,7 @@
 return [
     'Apply' => 'anwenden',
     'Cancel' => 'stornieren',
-    'Custom Range' => 'Kundenbereich',
+    'Custom Range' => 'Benutzerdefiniert',
     'From' => 'von',
     'Last Month' => 'Letzter Monat',
     'Last {n} Days' => 'Letzte {n} Tage',


### PR DESCRIPTION
Even though "Kundenbereich" is the literal translation of "Custom Range", the meaning of "Benutzerdefiniert" matches the context much better.