### PR TITLE
Depend on the 'yii\web\JqueryAsset'

### DIFF
--- a/DateRangePickerAsset.php
+++ b/DateRangePickerAsset.php
@@ -16,7 +16,10 @@ namespace kartik\daterange;
  */
 class DateRangePickerAsset extends \kartik\base\AssetBundle
 {
-    public $depends = ['\kartik\daterange\MomentAsset'];
+    public $depends = [
+        'yii\web\JqueryAsset',
+        '\kartik\daterange\MomentAsset'
+    ];
 
     /**
      * @inheritdoc


### PR DESCRIPTION
Fix an error ensuring that the js file is never included before jQuery.

(You need to evaluate this dependence in all of their assets that depend on jQuery)