### PR TITLE
Add Date Range Behavior

### DIFF
--- a/DateRangeBehavior.php
+++ b/DateRangeBehavior.php
@@ -1,0 +1,161 @@
+<?php
+namespace kartik\daterange;
+
+use yii\base\Model;
+use yii\base\Behavior;
+use yii\base\InvalidParamException;
+use yii\base\InvalidConfigException;
+
+/**
+ * DateRangeBehavior automatically fills the specified attributes with the parsed date range values.
+ *
+ * @author Cosmo <daixianceng@gmail.com>
+ */
+class DateRangeBehavior extends Behavior
+{
+    /**
+     * @var string the attribute that containing date range value.
+     */
+    public $attribute = 'date_range';
+
+    /**
+     * @var string the attribute that will receive date value formatted by `dateFormat`.
+     *     Required when `singleDate` set to `true`.
+     * @see $dateFormat
+     * @see $singleDate
+     */
+    public $dateAttribute;
+
+    /**
+     * @var string the attribute that will receive range start value formatted by `dateStartFormat`.
+     *     Required when `singleDate` set to `false`.
+     * @see $dateStartFormat
+     * @see $singleDate
+     */
+    public $dateStartAttribute;
+
+    /**
+     * @var string the attribute that will receive range end value formatted by `dateEndFormat`.
+     *     Required when `singleDate` set to `false`.
+     * @see $dateEndFormat
+     * @see $singleDate
+     */
+    public $dateEndAttribute;
+
+    /**
+     * @var string|null|false the PHP date format string. It will be used to format the date value.
+     *     If set to `null`, this will auto convert the date value into a Unix timestamp.
+     *     If set to `false`, there is no formatting action on the date value.
+     * @see $dateAttribute
+     */
+    public $dateFormat;
+
+    /**
+     * @var string|null|false the PHP date format string. It will be used to format the range start value.
+     *     If set to `null`, this will auto convert the range start value into a Unix timestamp.
+     *     If set to `false`, there is no formatting action on the range start value.
+     * @see $dateStartAttribute
+     */
+    public $dateStartFormat;
+
+    /**
+     * @var string|null|false the PHP date format string. It will be used to format the range end value.
+     *     If set to `null`, this will auto convert the range end value into a Unix timestamp.
+     *     If set to `false`, there is no formatting action on the range end value.
+     * @see $dateEndAttribute
+     */
+    public $dateEndFormat;
+
+    /**
+     * @var boolean whether the attribute is a single date. Defaults to `false`.
+     */
+    public $singleDate = false;
+
+    /**
+     * @var string the date range separator.
+     */
+    public $separator;
+
+    /**
+     * @inheritdoc
+     */
+    public function init()
+    {
+        parent::init();
+
+        if ($this->singleDate) {
+            if ($this->dateAttribute === null) {
+                throw new InvalidConfigException('The "dateAttribute" property must be specified.');
+            }
+        } else {
+            if ($this->dateStartAttribute === null || $this->dateEndAttribute === null) {
+                throw new InvalidConfigException('The "dateStartAttribute" and "dateEndAttribute" properties must be specified.');
+            }
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function events()
+    {
+        return [
+            Model::EVENT_AFTER_VALIDATE => 'afterValidate',
+        ];
+    }
+
+    /**
+     * Handles owner 'afterValidate' event.
+     * @param \yii\base\Event $event event instance.
+     */
+    public function afterValidate($event)
+    {
+        if (!$this->owner->hasErrors()) {
+            $dateRangeValue = $this->owner->{$this->attribute};
+            if (empty($dateRangeValue)) {
+                return;
+            }
+            if ($this->singleDate) {
+                $this->setOwnerAttribute($this->dateAttribute, $this->dateFormat, $dateRangeValue);
+            } else {
+                $separator = empty($this->separator) ? ' - ' : $this->separator;
+                $dates = explode($separator, $dateRangeValue, 2);
+                if (count($dates) !== 2) {
+                    throw new InvalidParamException("There is invalid date range: '{$dateRangeValue}'.");
+                }
+                $this->setOwnerAttribute($this->dateStartAttribute, $this->dateStartFormat, $dates[0]);
+                $this->setOwnerAttribute($this->dateEndAttribute, $this->dateEndFormat, $dates[1]);
+            }
+        }
+    }
+
+    /**
+     * Evaluates the attribute value and assigns it to the given attribute.
+     * @param string $attribute the owner attribute name
+     * @param string $dateFormat the PHP date format string
+     * @param string $date a date string
+     */
+    protected function setOwnerAttribute($attribute, $dateFormat, $date)
+    {
+        if ($dateFormat === false) {
+            $this->owner->$attribute = $date;
+        } else {
+            $timestamp = static::dateToTime($date);
+            if ($dateFormat === null) {
+                $this->owner->$attribute = $timestamp;
+            } else {
+                $this->owner->$attribute = $timestamp !== false ? date($dateFormat, $timestamp) : false;
+            }
+        }
+    }
+
+    /**
+     * Parses the given date into a Unix timestamp.
+     * @param string $date a date string
+     * @return integer|false a Unix timestamp. False on failure.
+     */
+    protected static function dateToTime($date)
+    {
+        return strtotime($date);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ yii2-date-range
 [![Monthly Downloads](https://poser.pugx.org/kartik-v/yii2-date-range/d/monthly)](https://packagist.org/packages/kartik-v/yii2-date-range)
 [![Daily Downloads](https://poser.pugx.org/kartik-v/yii2-date-range/d/daily)](https://packagist.org/packages/kartik-v/yii2-date-range)
 
-An advanced date range picker input for Yii Framework 2 based on [dangrossman/bootstrap-daterangepicker plugin](https://github.com/dangrossman/bootstrap-daterangepicker). 
-The date range picker widget is styled for Bootstrap 3.x and creates a dropdown menu from which a user can select a range of dates. If the plugin is invoked with no options, 
-it will present two calendars to choose a start and end date from. Optionally, you can provide a list of date ranges the user can select from instead of 
-choosing dates from the calendars. If attached to a text input, the selected dates will be inserted into the text box. Otherwise, you can provide a custom callback 
+An advanced date range picker input for Yii Framework 2 based on [dangrossman/bootstrap-daterangepicker plugin](https://github.com/dangrossman/bootstrap-daterangepicker).
+The date range picker widget is styled for Bootstrap 3.x and creates a dropdown menu from which a user can select a range of dates. If the plugin is invoked with no options,
+it will present two calendars to choose a start and end date from. Optionally, you can provide a list of date ranges the user can select from instead of
+choosing dates from the calendars. If attached to a text input, the selected dates will be inserted into the text box. Otherwise, you can provide a custom callback
 function to receive the selection.
 
 Additional enhancements added for this widget (by Krajee):
@@ -33,7 +33,7 @@ The latest version of the extension is release v1.6.6. Refer the [CHANGE LOG](ht
 
 The preferred way to install this extension is through [composer](http://getcomposer.org/download/).
 
-> Note: Check the [composer.json](https://github.com/kartik-v/yii2-date-range/blob/master/composer.json) for this extension's requirements and dependencies. 
+> Note: Check the [composer.json](https://github.com/kartik-v/yii2-date-range/blob/master/composer.json) for this extension's requirements and dependencies.
 Read this [web tip /wiki](http://webtips.krajee.com/setting-composer-minimum-stability-application/) on setting the `minimum-stability` settings for your application's composer.json.
 
 Either run
@@ -87,6 +87,57 @@ echo DateRangePicker::widget([
         ]
     ]
 ]);
+```
+
+### DateRangeBehavior
+
+```php
+use kartik\daterange\DateRangeBehavior;
+
+class UserSearch extends User
+{
+    public $createTimeRange;
+    public $createTimeStart;
+    public $createTimeEnd;
+
+    public function behaviors()
+    {
+        return [
+            [
+                'class' => DateRangeBehavior::className(),
+                'attribute' => 'createTimeRange',
+                'dateStartAttribute' => 'createTimeStart',
+                'dateEndAttribute' => 'createTimeEnd',
+            ]
+        ];
+    }
+
+    public function rules()
+    {
+        return [
+            // ...
+            [['createTimeRange'], 'match', 'pattern' => '/^.+\s\-\s.+$/'],
+        ];
+    }
+
+    public function search($params)
+    {
+        $query = User::find();
+        $dataProvider = new ActiveDataProvider([
+            'query' => $query,
+        ]);
+        $this->load($params);
+        if (!$this->validate()) {
+            $query->where('0=1');
+            return $dataProvider;
+        }
+
+        $query->andFilterWhere(['>=', 'createdAt', $this->createTimeStart])
+              ->andFilterWhere(['<', 'updatedAt', $this->createTimeEnd]);
+
+        return $dataProvider;
+    }
+}
 ```
 
 ## License


### PR DESCRIPTION
DateRangeBehavior automatically fills the specified attributes with the parsed date range values.

For example:

```php
use kartik\daterange\DateRangeBehavior;

class UserSearch extends User
{
    public $createTimeRange;
    public $createTimeStart;
    public $createTimeEnd;

    public function behaviors()
    {
        return [
            [
                'class' => DateRangeBehavior::className(),
                'attribute' => 'createTimeRange',
                'dateStartAttribute' => 'createTimeStart',
                'dateEndAttribute' => 'createTimeEnd',
            ]
        ];
    }

    public function rules()
    {
        return [
            // ...
            [['createTimeRange'], 'match', 'pattern' => '/^.+\s\-\s.+$/'],
        ];
    }

    public function search($params)
    {
        $query = User::find();
        $dataProvider = new ActiveDataProvider([
            'query' => $query,
        ]);
        $this->load($params);
        if (!$this->validate()) {
            $query->where('0=1');
            return $dataProvider;
        }

        $query->andFilterWhere(['>=', 'createdAt', $this->createTimeStart])
              ->andFilterWhere(['<', 'updatedAt', $this->createTimeEnd]);

        return $dataProvider;
    }
}
```