### PR TITLE
Fix default ranges

### DIFF
--- a/DateRangePicker.php
+++ b/DateRangePicker.php
@@ -320,26 +320,28 @@ HTML;
         if ($this->presetDropdown) {
             $this->initRangeExpr = $this->hideInput = true;
             $this->pluginOptions['opens'] = 'left';
-            $this->pluginOptions['ranges'] = [
-                Yii::t('kvdrp', "Today") => ["moment().startOf('day')", "moment()"],
-                Yii::t('kvdrp', "Yesterday") => [
-                    "moment().startOf('day').subtract(1,'days')",
-                    "moment().endOf('day').subtract(1,'days')"
-                ],
-                Yii::t('kvdrp', "Last {n} Days", ['n' => 7]) => [
-                    "moment().startOf('day').subtract(6, 'days')",
-                    "moment()"
-                ],
-                Yii::t('kvdrp', "Last {n} Days", ['n' => 30]) => [
-                    "moment().startOf('day').subtract(29, 'days')",
-                    "moment()"
-                ],
-                Yii::t('kvdrp', "This Month") => ["moment().startOf('month')", "moment().endOf('month')"],
-                Yii::t('kvdrp', "Last Month") => [
-                    "moment().subtract(1, 'month').startOf('month')",
-                    "moment().subtract(1, 'month').endOf('month')"
-                ],
-            ];
+            if (empty($this->pluginOptions['ranges'])) {
+                $this->pluginOptions['ranges'] = [
+                    Yii::t('kvdrp', "Today") => ["moment().startOf('day')", "moment()"],
+                    Yii::t('kvdrp', "Yesterday") => [
+                        "moment().startOf('day').subtract(1,'days')",
+                        "moment().endOf('day').subtract(1,'days')"
+                    ],
+                    Yii::t('kvdrp', "Last {n} Days", ['n' => 7]) => [
+                        "moment().startOf('day').subtract(6, 'days')",
+                        "moment()"
+                    ],
+                    Yii::t('kvdrp', "Last {n} Days", ['n' => 30]) => [
+                        "moment().startOf('day').subtract(29, 'days')",
+                        "moment()"
+                    ],
+                    Yii::t('kvdrp', "This Month") => ["moment().startOf('month')", "moment().endOf('month')"],
+                    Yii::t('kvdrp', "Last Month") => [
+                        "moment().subtract(1, 'month').startOf('month')",
+                        "moment().subtract(1, 'month').endOf('month')"
+                    ],
+                ];
+            }
             if (empty($this->value)) {
                 $this->pluginOptions['startDate'] = new JsExpression("moment().startOf('day')");
                 $this->pluginOptions['endDate'] = new JsExpression("moment()");


### PR DESCRIPTION
## Scope
This pull request includes a

- [X] Bug fix

## Changes
- Fixed pluginsOptions "ranges" default item

## Related Issues
There is an error where it is not possible to override the default value for "ranges"
This code has no effect:
```php
DateRangePicker::className(), [
	'presetDropdown' => true,
	'hideInput' => true,
	'pluginOptions' => [
		'ranges' => [
			'Неделя' => ["moment().startOf('day').subtract(6, 'days')", "moment()"],
		]
	]
]
```