### PR TITLE
Allow specifying direction in preset dropdown

### DIFF
--- a/CHANGE.md
+++ b/CHANGE.md
@@ -1,6 +1,10 @@
 Change Log: `yii2-date-range`
 =============================
 
+## Version 1.6.9
+
+- (bug #104): Allow specifying direction in preset dropdown
+
 ## Version 1.6.8
 
 **Date:** 08-Aug-2017

--- a/DateRangePicker.php
+++ b/DateRangePicker.php
@@ -401,7 +401,7 @@ JS;
         $m = 'moment()';
         if ($this->presetDropdown) {
             $this->initRangeExpr = $this->hideInput = true;
-            $this->pluginOptions['opens'] = 'left';
+            $this->pluginOptions['opens'] = ArrayHelper::getValue($this->pluginOptions, 'opens', 'left');
             $this->pluginOptions['ranges'] = [
                 Yii::t('kvdrp', 'Today') => ["{$m}.startOf('day')", $m],
                 Yii::t('kvdrp', 'Yesterday') => [


### PR DESCRIPTION
## Scope
This pull request includes a

- [ ] Bug fix
- [x] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-date-range/blob/master/CHANGE.md)):

- (bug #104): Allow specifying direction in preset dropdown

## Related Issues

#104  