### PR TITLE
Update initSettings to support indexes

### DIFF
--- a/src/DateRangePicker.php
+++ b/src/DateRangePicker.php
@@ -366,7 +366,7 @@ JS;
                 $end = $this->getRangeValue('end');
                 $this->value = $start . $this->_separator . $end;
                 if ($this->hasModel()) {
-                    $attr = $this->attribute;
+                    $attr = Html::getAttributeName($this->attribute);
                     $this->model->$attr = $this->value;
                 }
                 $this->pluginOptions['startDate'] = $start;


### PR DESCRIPTION
Fixes error when using array indexes in the attribute. For example if the attribute is [10]startDate the [10] is now stripped

## Scope
This pull request includes a

- [ x ] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-date-range/blob/master/CHANGE.md)):

- Fixes issue using array indexes in the attribute name
-
-

## Related Issues
[142](https://github.com/kartik-v/yii2-date-range/issues/142)