### PR TITLE
On 'apply.daterangepicker' should not depend on presetDropdown. This …

### DIFF
--- a/src/DateRangePicker.php
+++ b/src/DateRangePicker.php
@@ -340,18 +340,18 @@ HTML;
     drp.setEndDate(to);
     {$rangeJs}
 });
+{$id}.on('apply.daterangepicker', function() {
+    var drp = {$id}.data('{$this->pluginName}'), newValue = drp.startDate.format(drp.locale.format);
+    if (!drp.singleDatePicker) {
+        newValue += drp.locale.separator + drp.endDate.format(drp.locale.format);
+    }
+    if (newValue !== {$input}.val()) {
+        {$input}.val(newValue).trigger('change');
+    }
+});
 JS;
         if ($this->presetDropdown) {
             $js .= <<< JS
-    {$id}.on('apply.daterangepicker', function() {
-        var drp = {$id}.data('{$this->pluginName}'), newValue = drp.startDate.format(drp.locale.format);
-        if (!drp.singleDatePicker) {
-            newValue += drp.locale.separator + drp.endDate.format(drp.locale.format);
-        }
-        if (newValue !== {$input}.val()) {
-            {$input}.val(newValue).trigger('change');
-        }
-    });            
     {$id}.find('.range-value').attr('placeholder', {$input}.attr('placeholder'));
     {$id}.find('.kv-clear').on('click', function(e) {
         e.stopPropagation();


### PR DESCRIPTION
…corrects the error of not being able to select range for just today when presetDropdown is not set

## Scope
This pull request includes a

- [X] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-date-range/blob/master/CHANGE.md)):

-
-
-

## Related Issues
https://github.com/kartik-v/yii2-date-range/issues/158