### PR TITLE
SAPORTAONE-20 Removed yii2 base package because it exists in base addon

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
         }
     ],
     "require": {
-        "kartik-v/yii2-krajee-base": ">=3.0.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Removed yii2 base package because it exists in base addon.